### PR TITLE
Implement EEPROM saves

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,6 +291,7 @@ set(OS_POSIX_SOURCES
   ${PROJECT_SOURCE_DIR}/os/posix/alloc.c
   ${PROJECT_SOURCE_DIR}/os/posix/main.c
   ${PROJECT_SOURCE_DIR}/os/posix/rom_file.c
+  ${PROJECT_SOURCE_DIR}/os/posix/save_file.c
   ${PROJECT_SOURCE_DIR}/os/posix/timer.c
 )
 

--- a/device/device.c
+++ b/device/device.c
@@ -14,6 +14,7 @@
 #include "fpu/fpu.h"
 #include "gl_window.h"
 #include "os/common/rom_file.h"
+#include "os/common/save_file.h"
 
 #include "bus/controller.h"
 #include "ai/controller.h"
@@ -33,7 +34,8 @@ cen64_flatten cen64_hot static int device_spin(struct cen64_device *device);
 // Creates and initializes a device.
 struct cen64_device *device_create(struct cen64_device *device,
   const struct rom_file *ddipl, const struct rom_file *ddrom,
-  const struct rom_file *pifrom, const struct rom_file *cart) {
+  const struct rom_file *pifrom, const struct rom_file *cart,
+  const struct save_file *eeprom) {
 
   // Initialize the bus.
   device->bus.ai = &device->ai;
@@ -80,7 +82,7 @@ struct cen64_device *device_create(struct cen64_device *device,
 
   // Initialize the SI.
   if (si_init(&device->si, &device->bus, pifrom->ptr,
-    cart->ptr, ddipl->ptr != NULL)) {
+    cart->ptr, ddipl->ptr != NULL, eeprom->ptr, eeprom->size)) {
     debug("create_device: Failed to initialize the SI.\n");
     return NULL;
   }

--- a/device/device.h
+++ b/device/device.h
@@ -13,6 +13,7 @@
 #include "common.h"
 #include "device/options.h"
 #include "os/common/rom_file.h"
+#include "os/common/save_file.h"
 
 #include "ai/controller.h"
 #include "bus/controller.h"
@@ -47,7 +48,8 @@ struct cen64_device {
 cen64_cold void device_destroy(struct cen64_device *device);
 cen64_cold struct cen64_device *device_create(struct cen64_device *device,
   const struct rom_file *ddipl, const struct rom_file *ddrom,
-  const struct rom_file *pifrom, const struct rom_file *cart);
+  const struct rom_file *pifrom, const struct rom_file *cart,
+  const struct save_file *eeprom);
 
 cen64_cold void device_exit(struct bus_controller *bus);
 cen64_cold void device_run(struct cen64_device *device);

--- a/device/options.c
+++ b/device/options.c
@@ -17,6 +17,8 @@ const struct cen64_options default_cen64_options = {
   NULL, // pifrom_path
   NULL, // cart_path
   NULL, // debugger_addr
+  NULL, // eeprom_path
+  0,    // eeprom_size
 #ifdef _WIN32
   false, // console
 #endif
@@ -68,6 +70,26 @@ int parse_options(struct cen64_options *options, int argc, const char *argv[]) {
 
     else if (!strcmp(argv[i], "-nointerface"))
       options->no_interface = true;
+
+    else if (!strcmp(argv[i], "-eep4k")) {
+      if ((i + 1) >= (argc - 1)) {
+        printf("-eep4k requires a path to the save file.\n\n");
+        return 1;
+      }
+
+      options->eeprom_path = argv[++i];
+      options->eeprom_size = 4096;
+    }
+
+    else if (!strcmp(argv[i], "-eep16k")) {
+      if ((i + 1) >= (argc - 1)) {
+        printf("-eep16k requires a path to the save file.\n\n");
+        return 1;
+      }
+
+      options->eeprom_path = argv[++i];
+      options->eeprom_size = 16384;
+    }
 
     // TODO: Handle this better.
     else

--- a/device/options.h
+++ b/device/options.h
@@ -19,6 +19,9 @@ struct cen64_options {
   const char *cart_path;
   const char *debugger_addr;
 
+  const char *eeprom_path;
+  size_t eeprom_size;
+
 #ifdef _WIN32
   bool console;
 #endif

--- a/os/common/save_file.h
+++ b/os/common/save_file.h
@@ -1,0 +1,37 @@
+//
+// os/save_file.h
+//
+// Functions for mapping save files into the address space.
+//
+// This file is subject to the terms and conditions defined in
+// 'LICENSE', which is part of this source code package.
+//
+
+#ifndef __os_save_file_h__
+#define __os_save_file_h__
+#include "common.h"
+#include <stddef.h>
+
+#ifdef _WIN32
+#include <windows.h>
+
+struct save_file {
+  void *ptr;
+  size_t size;
+  HANDLE mapping;
+  HANDLE file;
+};
+
+#else
+struct save_file {
+  void *ptr;
+  size_t size;
+  int fd;
+};
+#endif
+
+cen64_cold int close_save_file(const struct save_file *file);
+cen64_cold int open_save_file(const char *path, size_t size, struct save_file *file);
+
+#endif
+

--- a/os/posix/save_file.c
+++ b/os/posix/save_file.c
@@ -1,0 +1,53 @@
+//
+// os/unix/save_file.c
+//
+// Functions for mapping save files into the address space.
+//
+// This file is subject to the terms and conditions defined in
+// 'LICENSE', which is part of this source code package.
+//
+
+#include "save_file.h"
+#include <fcntl.h>
+#include <stddef.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+// Unmaps a save file from he host address space.
+int close_save_file(const struct save_file *file) {
+  return munmap(file->ptr, file->size);
+}
+
+// Maps a save into the host address pace, returns a pointer.
+int open_save_file(const char *path, size_t size, struct save_file *file) {
+  struct stat sb;
+  void *ptr;
+  int fd;
+
+  // Open the file for read write, and create it if it doesn't exist.
+  if ((fd = open(path, O_RDWR | O_CREAT, 0666)) == -1)
+    return -1;
+
+  // Get the file's size, map it into the address space.
+  if (fstat(fd, &sb) == -1)
+    return -1;
+  
+  if ((size_t)sb.st_size != size)
+    if (ftruncate(fd, size) == -1) {
+      close(fd);
+      return -1;
+    }
+
+  if ((ptr = mmap(NULL, size, PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0)) == MAP_FAILED) {
+    close(fd);
+    return -1;
+  }
+
+  file->ptr = ptr;
+  file->size = size;
+  file->fd = fd;
+
+  return 0;
+}

--- a/si/controller.c
+++ b/si/controller.c
@@ -122,6 +122,65 @@ int pif_perform_command(struct si_controller *si,
 
       break;
 
+    // Read from controller pak
+    case 0x02:
+      if (channel < 4) {
+        // TODO
+        break;
+      }
+
+      else
+        assert(0 && "Invalid channel for controller pak read");
+
+      return 1;
+
+    // Write to controller pak
+    case 0x03:
+      if (channel < 4) {
+        // TODO
+        break;
+      }
+
+      else
+        assert(0 && "Invalid channel for controller pak write");
+
+      return 1;
+
+    // EEPROM read
+    case 0x04:
+      if (channel != 4)
+        assert(0 && "Invalid channel for EEPROM read");
+      // TODO
+      return 1;
+
+    // EEPROM write
+    case 0x05:
+      if (channel != 4)
+        assert(0 && "Invalid channel for EEPROM write");
+      // TODO
+      return 1;
+
+    // RTC status
+    case 0x06:
+      if (channel != 4)
+        assert(0 && "Invalid channel for RTC status");
+      // TODO
+      return 1;
+
+    // RTC read
+    case 0x07:
+      if (channel != 4)
+        assert(0 && "Invalid channel for RTC read");
+      // TODO
+      return 1;
+
+    // RTC write
+    case 0x08:
+      if (channel != 4)
+        assert(0 && "Invalid channel for RTC write");
+      // TODO
+      return 1;
+
     // Unimplemented command:
     default:
       return 1;

--- a/si/controller.c
+++ b/si/controller.c
@@ -37,7 +37,8 @@ static int eeprom_write(struct eeprom *eeprom, uint8_t *send_buf, uint8_t send_b
 
 // Initializes the SI.
 int si_init(struct si_controller *si, struct bus_controller *bus,
-  const uint8_t *pif_rom, const uint8_t *cart_rom, bool dd_present) {
+  const uint8_t *pif_rom, const uint8_t *cart_rom, bool dd_present,
+  const uint8_t *eeprom, size_t eeprom_size) {
   uint32_t cic_seed;
 
   si->bus = bus;
@@ -70,8 +71,8 @@ int si_init(struct si_controller *si, struct bus_controller *bus,
     bus_write_word(si, 0x3F0, 0x800000, ~0U);
 
   // initialize EEPROM
-  si->eeprom.size = EEPROM_SIZE;
-  // TODO zero memory?
+  si->eeprom.data = eeprom;
+  si->eeprom.size = eeprom_size;
 
   return 0;
 }

--- a/si/controller.c
+++ b/si/controller.c
@@ -32,6 +32,9 @@ static void pif_process(struct si_controller *si);
 static int pif_perform_command(struct si_controller *si, unsigned channel,
   uint8_t *send_buf, uint8_t send_bytes, uint8_t *recv_buf, uint8_t recv_bytes);
 
+static int eeprom_read(struct eeprom *eeprom, uint8_t *send_buf, uint8_t send_bytes, uint8_t *recv_buf, uint8_t recv_bytes);
+static int eeprom_write(struct eeprom *eeprom, uint8_t *send_buf, uint8_t send_bytes, uint8_t *recv_buf, uint8_t recv_bytes);
+
 // Initializes the SI.
 int si_init(struct si_controller *si, struct bus_controller *bus,
   const uint8_t *pif_rom, const uint8_t *cart_rom, bool dd_present) {
@@ -65,6 +68,10 @@ int si_init(struct si_controller *si, struct bus_controller *bus,
 
   else if (si->ram[0x26] == 0x91 && si->ram[0x27] == 0x3F)
     bus_write_word(si, 0x3F0, 0x800000, ~0U);
+
+  // initialize EEPROM
+  si->eeprom.size = EEPROM_SIZE;
+  // TODO zero memory?
 
   return 0;
 }
@@ -150,15 +157,13 @@ int pif_perform_command(struct si_controller *si,
     case 0x04:
       if (channel != 4)
         assert(0 && "Invalid channel for EEPROM read");
-      // TODO
-      return 1;
+      return eeprom_read(&si->eeprom, send_buf, send_bytes, recv_buf, recv_bytes);
 
     // EEPROM write
     case 0x05:
       if (channel != 4)
         assert(0 && "Invalid channel for EEPROM write");
-      // TODO
-      return 1;
+      return eeprom_write(&si->eeprom, send_buf, send_bytes, recv_buf, recv_bytes);
 
     // RTC status
     case 0x06:
@@ -345,3 +350,29 @@ int write_si_regs(void *opaque, uint32_t address, uint32_t word, uint32_t dqm) {
   return 0;
 }
 
+
+int eeprom_read(struct eeprom *eeprom, uint8_t *send_buf, uint8_t send_bytes, uint8_t *recv_buf, uint8_t recv_bytes) {
+  assert(send_bytes == 2 && recv_bytes == 8);
+
+  uint16_t address = send_buf[1] << 3;
+
+  if (address <= eeprom->size - 8) {
+    memcpy(recv_buf, &eeprom->data[address], 8);
+    return 0;
+  }
+
+  return 1;
+}
+
+static int eeprom_write(struct eeprom *eeprom, uint8_t *send_buf, uint8_t send_bytes, uint8_t *recv_buf, uint8_t recv_bytes) {
+  assert(send_bytes == 10);
+
+  uint16_t address = send_buf[1] << 3;
+
+  if (address <= eeprom->size - 8) {
+    memcpy(&eeprom->data[address], send_buf + 2, 8);
+    return 0;
+  }
+
+  return 1;
+}

--- a/si/controller.c
+++ b/si/controller.c
@@ -101,8 +101,12 @@ int pif_perform_command(struct si_controller *si,
           return 1;
 
         case 4:
+          // XXX hack alert: this returns 16k EEPROM in the case of a
+          // 16k EEPROM and returns 4k EEPROM in all other cases. This
+          // is likely a hack to make games that expect EEPROM work,
+          // even if the user doesn't supply one on the command line.
           recv_buf[0] = 0x00;
-          recv_buf[1] = 0x80;
+          recv_buf[1] = si->eeprom.size == 16384 ? 0xC0 : 0x80;
           recv_buf[2] = 0x00;
           break;
 

--- a/si/controller.h
+++ b/si/controller.h
@@ -25,9 +25,8 @@ enum si_register {
 extern const char *si_register_mnemonics[NUM_SI_REGISTERS];
 #endif
 
-#define EEPROM_SIZE 0x800
 struct eeprom {
-  uint8_t data[EEPROM_SIZE];
+  uint8_t *data;
   size_t size;
 };
 
@@ -44,7 +43,8 @@ struct si_controller {
 };
 
 cen64_cold int si_init(struct si_controller *si, struct bus_controller *bus,
-  const uint8_t *pif_rom, const uint8_t *cart_rom, bool dd_present);
+  const uint8_t *pif_rom, const uint8_t *cart_rom, bool dd_present,
+  const uint8_t *eeprom, size_t eeprom_size);
 
 int read_pif_ram(void *opaque, uint32_t address, uint32_t *word);
 int read_pif_rom(void *opaque, uint32_t address, uint32_t *word);

--- a/si/controller.h
+++ b/si/controller.h
@@ -25,6 +25,12 @@ enum si_register {
 extern const char *si_register_mnemonics[NUM_SI_REGISTERS];
 #endif
 
+#define EEPROM_SIZE 0x800
+struct eeprom {
+  uint8_t data[EEPROM_SIZE];
+  size_t size;
+};
+
 struct si_controller {
   struct bus_controller *bus;
   const uint8_t *rom;
@@ -34,6 +40,7 @@ struct si_controller {
   uint32_t regs[NUM_SI_REGISTERS];
   uint32_t pif_status;
   uint8_t input[4];
+  struct eeprom eeprom;
 };
 
 cen64_cold int si_init(struct si_controller *si, struct bus_controller *bus,


### PR DESCRIPTION
This PR implements EEPROM saves (both 4k and 16k) as well as stubbing out a bunch of other unimplemented PIF commands. It also introduces struct save_file as a generic format for loading saves.