### PR TITLE
Minor fixes to SI

### DIFF
--- a/si/controller.c
+++ b/si/controller.c
@@ -257,7 +257,8 @@ void pif_process(struct si_controller *si) {
     channel++;
   }
 
-  si->ram[0x3F] = 0;
+  // clear the PIF's busy flag
+  si->ram[0x3F] &= ~0x80;
 }
 
 // Reads a word from PIF RAM.

--- a/si/controller.c
+++ b/si/controller.c
@@ -109,9 +109,10 @@ int pif_perform_command(struct si_controller *si,
             recv_buf[0] = 0x05;
             recv_buf[1] = 0x00;
             recv_buf[2] = si->controller[channel].pak == PAK_NONE ? 0x00 : 0x01;
-            break;
           }
-          return 1;
+          else
+            recv_buf[0] = recv_buf[1] = recv_buf[2] = 0;
+          break;
 
         case 4:
           // XXX hack alert: this returns 16k EEPROM in the case of a

--- a/si/pak_transfer.c
+++ b/si/pak_transfer.c
@@ -80,7 +80,7 @@ void transfer_pak_write(struct controller *controller,
   else if (address >= 0xC000) {
     uint16_t gb_addr = address - 0xC000
       + (controller->tpak_bank & 3) * 0x4000;
-    gameboy_write(controller, gb_addr, send_buf);
+    gameboy_write(controller, gb_addr, send_buf + 3);
   }
 }
 


### PR DESCRIPTION
Correct controller behavior, don't blow away PIF status byte (fixes transfer pak misbehavior), and send correct buffer to GB write function.