### PR TITLE
Add support for MBC3 for tpak

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -349,6 +349,7 @@ set(SI_SOURCES
   ${PROJECT_SOURCE_DIR}/si/controller.c
   ${PROJECT_SOURCE_DIR}/si/pak.c
   ${PROJECT_SOURCE_DIR}/si/pak_transfer.c
+  ${PROJECT_SOURCE_DIR}/si/gb.c
 )
 
 set(VI_SOURCES

--- a/cen64.c
+++ b/cen64.c
@@ -233,6 +233,7 @@ int load_paks(struct controller *controller) {
         printf("No save supplied for transfer pak. Just FYI.\n");
       }
 
+      gb_init(&controller[i]);
     }
   }
   return 0;

--- a/si/gb.c
+++ b/si/gb.c
@@ -208,7 +208,7 @@ void mbc_mbc3_write_ram_bank_select( struct controller *controller, uint16_t add
 
 // write 6000-7FFF
 void mbc_mbc3_write_clock_data_latch( struct controller *controller, uint16_t address, uint8_t data ) {
-  printf("wrote clock data latch: %04X:%02X\n", address, data);
+  // TODO
 }
 
 // read A000-BFFF extram
@@ -223,9 +223,10 @@ void mbc_mbc3_write_extram( struct controller *controller, uint16_t address, uin
 
 // read A000-BFFF rtc
 uint8_t mbc_mbc3_read_rtc( struct controller *controller, uint16_t address ) {
-  return 0x00;
+  return 0x00;  // TODO
 }
 
 // write A000-BFFF rtc
 void mbc_mbc3_write_rtc( struct controller *controller, uint16_t address, uint8_t data ) {
+  // TODO
 }

--- a/si/gb.c
+++ b/si/gb.c
@@ -1,0 +1,213 @@
+#include <stddef.h>
+#include "pak.h"
+#include "gb.h"
+
+void cart_reset_mbc(struct controller *controller);
+void cart_default_cleanup();
+
+uint8_t gb_read(struct controller *controller, uint16_t address) {
+  uint8_t (*myfunc)(struct controller *,uint16_t) = controller->gb_readmem[address>>8];
+  uint8_t data;
+  if(myfunc != NULL)
+    data = myfunc(controller, address);
+  else
+    data = 0xFF;
+//   printf("gb_read: %04X:%02X\n", address, data);
+  return data;
+}
+
+void gb_write(struct controller *controller, uint16_t address, uint8_t data) {
+  void (*myfunc)(struct controller *,uint16_t,uint8_t) = controller->gb_writemem[address>>8];
+  if(myfunc != NULL)
+    myfunc(controller, address, data);
+//   printf("gb_write: %04X:%02X\n", address, data);
+}
+
+void gb_init(struct controller *controller) {
+  printf("gb_init\n");
+  for(int i=0;i<0x100;i++) {
+    controller->gb_readmem [i] = NULL;
+    controller->gb_writemem[i] = NULL;
+  }
+  
+  // set up cart params
+  struct gb_cart *cart = &controller->cart;
+  cart->cartromsize = controller->tpak_rom.size;
+  cart->cartrom = (uint8_t *)(controller->tpak_rom.ptr);
+  cart->cartrom_bank_zero = cart->cartrom;
+  cart->cartrom_bank_n = cart->cartrom + 0x4000;
+  cart->extram = (uint8_t *)(controller->tpak_save.ptr);
+  cart->extram_bank = cart->extram;
+  cart->extram_size=32768;  // HACK
+  
+  mbc_mbc3_install(controller);
+}
+
+void mbc_mbc3_install(struct controller *controller)
+{
+  int i;
+  // cart bank zero
+  for( i=0x00; i<=0x3F; ++i ) {
+    controller->gb_readmem[i] = mbc_mbc3_read_bank_0;
+  }
+  // cart bank n
+  for( i=0x40; i<=0x7F; ++i ) {
+    controller->gb_readmem[i] = mbc_mbc3_read_bank_n;
+  }
+  
+  // write 0000-1FFF: ram enable
+  for( i=0x00; i<=0x1F; ++i ) {
+    controller->gb_writemem[i] = mbc_mbc3_write_ram_enable;
+  }
+  // write 2000-3FFF: rom bank select
+  for( i=0x20; i<=0x3F; ++i ) {
+    controller->gb_writemem[i] = mbc_mbc3_write_rom_bank_select;
+  }
+  // write 4000-5FFF: ram bank select
+  for( i=0x40; i<=0x5F; ++i ) {
+    controller->gb_writemem[i] = mbc_mbc3_write_ram_bank_select;
+  }
+  // write 6000-7FFF: clock data latch
+  for( i=0x60; i<=0x7F; ++i ) {
+    controller->gb_writemem[i] = mbc_mbc3_write_clock_data_latch;
+  }
+  
+  // read A000-BFFF: read extram
+  // calculate the last address where extram is installed
+  int extram_end = 0xA0 + (controller->cart.extram_size>8192?8192:controller->cart.extram_size)/256;
+  for( i=0xA0; i<extram_end; ++i ) {
+    controller->gb_readmem[i] = mbc_mbc3_read_extram;
+  }
+  for( i=extram_end; i<=0xBF; ++i ) {
+    controller->gb_readmem[i] = mbc_mbc3_read_ff;
+  }
+  
+  // write A000-BFFF: write extram
+  for( i=0xA0; i<extram_end; ++i ) {
+    controller->gb_writemem[i] = mbc_mbc3_write_extram;
+  }
+  for( i=extram_end; i<=0xBF; ++i ) {
+    controller->gb_writemem[i] = mbc_mbc3_write_dummy;
+  }
+  
+}
+
+uint8_t mbc_mbc3_read_ff( struct controller *controller, uint16_t address )
+{
+  return 0xff;
+}
+
+void mbc_mbc3_write_dummy( struct controller *controller, uint16_t address, uint8_t data )
+{
+}
+
+uint8_t mbc_mbc3_read_bank_0( struct controller *controller, uint16_t address )
+{
+  return controller->cart.cartrom_bank_zero[address];
+}
+
+uint8_t mbc_mbc3_read_bank_n( struct controller *controller, uint16_t address )
+{
+  return controller->cart.cartrom_bank_n[address&0x3fff];
+}
+
+// write 0000-1FFF
+void mbc_mbc3_write_ram_enable( struct controller *controller, uint16_t address, uint8_t data )
+{
+  // TODO
+}
+
+// write 2000-3FFF
+void mbc_mbc3_write_rom_bank_select( struct controller *controller, uint16_t address, uint8_t data ) {
+  
+  struct gb_cart *cart = &controller->cart;
+  
+  size_t offset;
+  data &= 0x7F;
+  cart->cart_bank_num = data;
+  if( data == 0 )
+    offset = (size_t)16384;
+  else
+    offset = (size_t)data*16384 % cart->cartromsize;
+  
+//   printf( "switch cart bank num: %02X\n", cart->cart_bank_num );
+//   assert("MBC3 rom bank select: offset computation", offset <= (cart->cartromsize - 16384));
+  cart->cartrom_bank_n = cart->cartrom + offset;
+}
+
+// write 4000-5FFF
+void mbc_mbc3_write_ram_bank_select( struct controller *controller, uint16_t address, uint8_t data ) {
+  struct gb_cart *cart = &controller->cart;
+  int i;
+  switch( data )
+  {
+    case 0x00:
+    case 0x01:
+    case 0x02:
+    case 0x03:
+//       printf("Switching to RAM bank %02X \n", data );
+      cart->extram_bank_num = data;
+      cart->extram_bank = cart->extram + data*8192;
+      // read A000-BFFF: read extram
+      // calculate the last address where extram is installed
+      int extram_end = 0xA0 + (cart->extram_size>8192?8192:cart->extram_size)/256;
+      for( i=0xA0; i<extram_end; ++i ) {
+        controller->gb_readmem[i] = mbc_mbc3_read_extram;
+      }
+      for( i=extram_end; i<=0xBF; ++i ) {
+        controller->gb_readmem[i] = mbc_mbc3_read_ff;
+      }
+      
+      // write A000-BFFF: write extram
+      for( i=0xA0; i<extram_end; ++i ) {
+        controller->gb_writemem[i] = mbc_mbc3_write_extram;
+      }
+      for( i=extram_end; i<=0xBF; ++i ) {
+        controller->gb_writemem[i] = mbc_mbc3_write_dummy;
+      }
+      break;
+    case 0x08:	// seconds
+    case 0x09:	// minutes
+    case 0x0A:	// hours
+    case 0x0B:	// day bits 0-7
+    case 0x0C:	// day bit 8, carry bit, halt flag
+//       printf("Switching to RTC bank %02X \n", data );
+      cart->extram_bank_num = data;
+      // read A000-BFFF: read rtc
+      for( i=0xA0; i<=0xBF; ++i ) {
+	controller->gb_readmem[i] = mbc_mbc3_read_rtc;
+      }
+      // write A000-BFFF: write rtc
+      for( i=0xA0; i<=0xBF; ++i ) {
+	controller->gb_writemem[i] = mbc_mbc3_write_rtc;
+      }
+      break;
+    default:
+      printf("Switching to invalid extram bank %02X \n", data );
+      break;
+  }
+}
+
+// write 6000-7FFF
+void mbc_mbc3_write_clock_data_latch( struct controller *controller, uint16_t address, uint8_t data ) {
+  printf("wrote clock data latch: %04X:%02X\n", address, data);
+}
+
+// read A000-BFFF extram
+uint8_t mbc_mbc3_read_extram( struct controller *controller, uint16_t address ) {
+  return controller->cart.extram_bank[address&0x1fff];
+}
+
+// write A000-BFFF extram
+void mbc_mbc3_write_extram( struct controller *controller, uint16_t address, uint8_t data ) {
+  controller->cart.extram_bank[address&0x1fff] = data;
+}
+
+// read A000-BFFF rtc
+uint8_t mbc_mbc3_read_rtc( struct controller *controller, uint16_t address ) {
+  return 0x00;
+}
+
+// write A000-BFFF rtc
+void mbc_mbc3_write_rtc( struct controller *controller, uint16_t address, uint8_t data ) {
+}

--- a/si/gb.c
+++ b/si/gb.c
@@ -34,7 +34,6 @@ void gb_write(struct controller *controller, uint16_t address, uint8_t data) {
 }
 
 void gb_init(struct controller *controller) {
-  printf("gb_init\n");
   for(int i=0;i<0x100;i++) {
     controller->gb_readmem [i] = NULL;
     controller->gb_writemem[i] = NULL;

--- a/si/gb.c
+++ b/si/gb.c
@@ -1,3 +1,13 @@
+//
+// si/gb.c: Game Boy pak functions
+//
+// CEN64: Cycle-Accurate Nintendo 64 Emulator.
+// Copyright (C) 2016, Jason Benaim.
+//
+// This file is subject to the terms and conditions defined in
+// 'LICENSE', which is part of this source code package.
+//
+
 #include <stddef.h>
 #include "pak.h"
 #include "gb.h"

--- a/si/gb.c
+++ b/si/gb.c
@@ -40,15 +40,23 @@ void gb_init(struct controller *controller) {
     controller->gb_writemem[i] = NULL;
   }
   
-  // set up cart params
   struct gb_cart *cart = &controller->cart;
+  
+  // set up pak rom
   cart->cartromsize = controller->tpak_rom.size;
   cart->cartrom = (uint8_t *)(controller->tpak_rom.ptr);
   cart->cartrom_bank_zero = cart->cartrom;
   cart->cartrom_bank_n = cart->cartrom + 0x4000;
-  cart->extram = (uint8_t *)(controller->tpak_save.ptr);
+  
+  // set up pak ram
+  if( controller->tpak_save.ptr != NULL ) {
+    cart->extram = (uint8_t *)(controller->tpak_save.ptr);
+    cart->extram_size = controller->tpak_save.size;
+  } else {
+    cart->extram = calloc( 1, 65536 );  // TODO: deallocate this eventually?
+    cart->extram_size = 65536;
+  }   
   cart->extram_bank = cart->extram;
-  cart->extram_size=32768;  // HACK
   
   mbc_mbc3_install(controller);
 }

--- a/si/gb.h
+++ b/si/gb.h
@@ -1,3 +1,13 @@
+//
+// si/gb.h: Game Boy pak definitions
+//
+// CEN64: Cycle-Accurate Nintendo 64 Emulator.
+// Copyright (C) 2016, Jason Benaim.
+//
+// This file is subject to the terms and conditions defined in
+// 'LICENSE', which is part of this source code package.
+//
+
 #ifndef __si_gb_h__
 #define __si_gb_h__
 #include "pak.h"

--- a/si/gb.h
+++ b/si/gb.h
@@ -1,0 +1,55 @@
+#ifndef __si_gb_h__
+#define __si_gb_h__
+#include "pak.h"
+
+struct gb_cart {
+  int mbc_type;
+  int cartrom_num_banks;
+  int reg_rom_bank_low;	// low bits of ROM bank
+  int reg_rom_bank_high;  // high bits of ROM bank
+  uint8_t* bootrom;
+  size_t bootromsize;
+  uint8_t* cartrom;
+  uint8_t* cartromValid;
+  uint8_t* cartrom_bank_zero;
+  uint8_t* cartrom_bank_n;
+  uint8_t* cartromValid_bank_n;
+  uint16_t cart_bank_num;
+  size_t cartromsize;
+  uint8_t* extram;
+  uint8_t* extramValidRead;
+  uint8_t* extramValidWrite;
+  uint8_t* extram_bank;
+  uint8_t* extram_bank_validRead;
+  uint8_t* extram_bank_validWrite;
+  uint8_t extram_bank_num;
+  int extramEnabled;
+  size_t extram_size;
+  int extram_num_banks;
+  int battery_backed;
+  void (*cleanup)(void);
+  char savename[256];
+  int huc3_ram_mode;
+  FILE *fd;
+  int chardev_mode;
+};
+
+struct controller;
+uint8_t gb_read(struct controller *controller, uint16_t address);
+void gb_write(struct controller *controller, uint16_t address, uint8_t data);
+void gb_init(struct controller *controller);
+
+extern void mbc_mbc3_install( struct controller *controller );
+uint8_t mbc_mbc3_read_ff( struct controller *controller, uint16_t address );
+void mbc_mbc3_write_dummy( struct controller *controller, uint16_t address, uint8_t data );
+uint8_t mbc_mbc3_read_bank_0( struct controller *controller, uint16_t address );
+uint8_t mbc_mbc3_read_bank_n( struct controller *controller, uint16_t address );
+void mbc_mbc3_write_ram_enable( struct controller *controller, uint16_t address, uint8_t data );
+void mbc_mbc3_write_rom_bank_select( struct controller *controller, uint16_t address, uint8_t data );
+void mbc_mbc3_write_ram_bank_select( struct controller *controller, uint16_t address, uint8_t data );
+void mbc_mbc3_write_clock_data_latch( struct controller *controller, uint16_t address, uint8_t data );
+uint8_t mbc_mbc3_read_extram( struct controller *controller, uint16_t address );
+void mbc_mbc3_write_extram( struct controller *controller, uint16_t address, uint8_t data );
+uint8_t mbc_mbc3_read_rtc( struct controller *controller, uint16_t address );
+void mbc_mbc3_write_rtc( struct controller *controller, uint16_t address, uint8_t data );
+#endif

--- a/si/pak.h
+++ b/si/pak.h
@@ -13,6 +13,7 @@
 #include "common.h"
 #include "os/common/rom_file.h"
 #include "os/common/save_file.h"
+#include "gb.h"
 
 #define MEMPAK_SIZE 0x8000
 
@@ -27,6 +28,11 @@ struct controller {
   const char *mempak_path;
   struct save_file mempak_save;
 
+  enum pak_type pak;
+  int pak_enabled;
+  int present;
+  
+  // tpak stuff
   const char *tpak_rom_path;
   struct rom_file tpak_rom;
   const char *tpak_save_path;
@@ -34,10 +40,11 @@ struct controller {
   int tpak_mode;
   int tpak_mode_changed;
   int tpak_bank;
-
-  enum pak_type pak;
-  int pak_enabled;
-  int present;
+  
+  // gb cart stuff
+  uint8_t (*gb_readmem [0x100])(struct controller *controller, uint16_t address);
+  void    (*gb_writemem[0x100])(struct controller *controller, uint16_t address, uint8_t data);
+  struct gb_cart cart;
 };
 
 void controller_pak_format(uint8_t *ptr);

--- a/si/pak_transfer.c
+++ b/si/pak_transfer.c
@@ -9,6 +9,7 @@
 //
 
 #include "pak.h"
+#include "gb.h"
 
 static void gameboy_read(struct controller *controller, uint16_t address,
     uint8_t *buffer);
@@ -87,13 +88,21 @@ void transfer_pak_write(struct controller *controller,
 // read 0x20 bytes from Game Boy cart at address
 void gameboy_read(struct controller *controller, uint16_t address,
     uint8_t *buffer) {
-  // TODO handle mappers
-  if (address < 0x8000)
-    memcpy(buffer, controller->tpak_rom.ptr + address, 0x20);
+  for(int i=0;i<0x20;i++)
+    buffer[i] = gb_read(controller, address+i);
+  
+//   printf("read:  %04X: ", address);
+//   for(int i=0;i<32;i++) {
+//     if(i==16) printf("\n             ");
+//     printf("%02X ", buffer[i]);
+//   }
+//   printf("\n");
 }
 
 // write 0x20 bytes from buffer to Game Boy cart at address
 void gameboy_write(struct controller *controller, uint16_t address,
     uint8_t *buffer) {
-  // TODO
+  for(int i=0;i<0x20;i++)
+    gb_write(controller, address+i, buffer[i]);
+//   printf("write: %04X:%02X\n", address, buffer[0]);
 }

--- a/si/pak_transfer.c
+++ b/si/pak_transfer.c
@@ -1,5 +1,5 @@
 //
-// si/pak.c: Controller pak routines
+// si/pak_transfer.c: Controller pak routines
 //
 // CEN64: Cycle-Accurate Nintendo 64 Emulator.
 // Copyright (C) 2016, Mike Ryan.


### PR DESCRIPTION
![ladin](https://cloud.githubusercontent.com/assets/2214896/12631922/56885a48-c522-11e5-9b4b-57913b19f504.png)

This is the bare minimum necessary to get Pokemon games working with the transfer pak. More work is needed to get other Game Boy games working.

To use the transfer pak, start CEN64 like so:
cen64 -controller num=1,tpak_rom=GAME.GB,tpak_save=GAME.SAV pifdata.bin rom.z64