### PR TITLE
Clear reset type bits in CIC seed values from PIF

### DIFF
--- a/si/cic.c
+++ b/si/cic.c
@@ -11,12 +11,19 @@
 #include "common.h"
 #include "si/cic.h"
 
+// CIC seeds and status bits passed from PIF to IPL through PIF RAM
+// Bits     | Description
+// 00080000 | ROM type (0 = Game Pack, 1 = DD)
+// 00040000 | Version
+// 00020000 | Reset Type (0 = cold reset, 1 = NMI)
+// 0000FF00 | CIC IPL3 seed value
+// 000000FF | CIC IPL2 seed value
 #define CIC_SEED_NUS_5101 0x0000AC00U
-#define CIC_SEED_NUS_6101 0x00063F3FU
-#define CIC_SEED_NUS_6102 0x00023F3FU
-#define CIC_SEED_NUS_6103 0x0002783FU
-#define CIC_SEED_NUS_6105 0x0002913FU
-#define CIC_SEED_NUS_6106 0x0002853FU
+#define CIC_SEED_NUS_6101 0x00043F3FU
+#define CIC_SEED_NUS_6102 0x00003F3FU
+#define CIC_SEED_NUS_6103 0x0000783FU
+#define CIC_SEED_NUS_6105 0x0000913FU
+#define CIC_SEED_NUS_6106 0x0000853FU
 #define CIC_SEED_NUS_8303 0x0000DD00U
 
 #define CRC_NUS_5101 0x587BD543U


### PR DESCRIPTION
Some CIC seed values had bit 0x20000 set which is the reset type
indicated from PIF (1 = NMI, 0 = Cold Reset). Some games
follow different initialization paths for NMIs which can cause
some unexpected boot behavior during a cold reset.

Fixes #58 Expansion Pak detection in Perfect Dark