### PR TITLE
Verify save file options for entries in cart DB

### DIFF
--- a/cen64.c
+++ b/cen64.c
@@ -100,7 +100,7 @@ int cen64_main(int argc, const char **argv) {
     switch (cart_info->save_type) {
       case CART_DB_SAVE_TYPE_EEPROM_4KBIT:
         if (options.eeprom_path == NULL) {
-          printf("Warning: cart expects 4kbit EEPROM, but none specified (see -eep4k)\n");
+          printf("Warning: cart saves to 4kbit EEPROM, but none specified (see -eep4k)\n");
           open_save_file(NULL, 0x200, &eeprom, NULL);
         } else {
           if (options.eeprom_size != 0x200)
@@ -109,7 +109,7 @@ int cen64_main(int argc, const char **argv) {
         break;
       case CART_DB_SAVE_TYPE_EEPROM_16KBIT:
         if (options.eeprom_path == NULL) {
-          printf("Warning: cart expects 16kbit EEPROM, but none specified (see -eep16k)\n");
+          printf("Warning: cart saves to 16kbit EEPROM, but none specified (see -eep16k)\n");
           open_save_file(NULL, 0x800, &eeprom, NULL);
         } else {
           if (options.eeprom_size != 0x800)

--- a/os/posix/save_file.c
+++ b/os/posix/save_file.c
@@ -34,7 +34,8 @@ int open_save_file(const char *path, size_t size, struct save_file *file, int *c
   int my_created;
 
   if (path == NULL) {
-    ptr = calloc(size, 1);
+    if ((ptr = calloc(size, 1)) == NULL)
+      return -1;
     fd = -1;
     if (created != NULL)
       *created = 1;

--- a/os/winapi/save_file.c
+++ b/os/winapi/save_file.c
@@ -34,7 +34,8 @@ int open_save_file(const char *path, size_t size,
   int my_created;
 
   if (path == NULL) {
-    ptr = calloc(size, 1);
+    if ((ptr = calloc(size, 1)) == NULL)
+      return -1;
     mapping = NULL;
     hfile = NULL;
     if (created != NULL)

--- a/os/winapi/save_file.c
+++ b/os/winapi/save_file.c
@@ -13,9 +13,13 @@
 
 // Unmaps a save image from the host address space.
 int close_save_file(const struct save_file *file) {
-  UnmapViewOfFile(file->ptr);
-  CloseHandle(file->mapping);
-  CloseHandle(file->file);
+  if (file->file != NULL) {
+    UnmapViewOfFile(file->ptr);
+    CloseHandle(file->mapping);
+    CloseHandle(file->file);
+  } else {
+    free(file->ptr);
+  }
 
   return 0;
 }
@@ -29,49 +33,57 @@ int open_save_file(const char *path, size_t size,
   LARGE_INTEGER sz;
   int my_created;
 
-  // Open the file, get its size.
-  if ((hfile = CreateFile(path, GENERIC_READ | GENERIC_WRITE,
-    0, NULL, OPEN_EXISTING, FILE_FLAG_RANDOM_ACCESS, NULL))
-    != INVALID_HANDLE_VALUE)
-    my_created = 0;
-
-  else {
+  if (path == NULL) {
+    ptr = calloc(size, 1);
+    mapping = NULL;
+    hfile = NULL;
+    if (created != NULL)
+      *created = 1;
+  } else {
+    // Open the file, get its size.
     if ((hfile = CreateFile(path, GENERIC_READ | GENERIC_WRITE,
-      0, NULL, CREATE_NEW, FILE_FLAG_RANDOM_ACCESS, NULL))
-      == INVALID_HANDLE_VALUE)
-      return -1;
-    my_created = 1;
-  }
+      0, NULL, OPEN_EXISTING, FILE_FLAG_RANDOM_ACCESS, NULL))
+      != INVALID_HANDLE_VALUE)
+      my_created = 0;
 
-  if (created != NULL)
-    *created = my_created;
+    else {
+      if ((hfile = CreateFile(path, GENERIC_READ | GENERIC_WRITE,
+        0, NULL, CREATE_NEW, FILE_FLAG_RANDOM_ACCESS, NULL))
+        == INVALID_HANDLE_VALUE)
+        return -1;
+      my_created = 1;
+    }
 
-  sz.QuadPart = size;
-  if(SetFilePointerEx(hfile, sz, NULL, FILE_BEGIN) == FALSE) {
-    CloseHandle(hfile);
+    if (created != NULL)
+      *created = my_created;
 
-    return -4;
-  }
-  if(SetEndOfFile(hfile) == FALSE) {
-    CloseHandle(hfile);
+    sz.QuadPart = size;
+    if(SetFilePointerEx(hfile, sz, NULL, FILE_BEGIN) == FALSE) {
+      CloseHandle(hfile);
 
-    return -5;
-  }
+      return -4;
+    }
+    if(SetEndOfFile(hfile) == FALSE) {
+      CloseHandle(hfile);
 
-  // Create a mapping and effectively enable it.
-  if ((mapping = CreateFileMapping(hfile, NULL,
-    PAGE_READWRITE, 0, 0, NULL)) == NULL) {
-    CloseHandle(hfile);
+      return -5;
+    }
 
-    return -2;
-  }
+    // Create a mapping and effectively enable it.
+    if ((mapping = CreateFileMapping(hfile, NULL,
+      PAGE_READWRITE, 0, 0, NULL)) == NULL) {
+      CloseHandle(hfile);
 
-  if ((ptr = MapViewOfFile(mapping, FILE_MAP_READ | FILE_MAP_WRITE,
-    0, 0, 0)) == NULL) {
-    CloseHandle(mapping);
-    CloseHandle(hfile);
+      return -2;
+    }
 
-    return -3;
+    if ((ptr = MapViewOfFile(mapping, FILE_MAP_READ | FILE_MAP_WRITE,
+      0, 0, 0)) == NULL) {
+      CloseHandle(mapping);
+      CloseHandle(hfile);
+
+      return -3;
+    }
   }
 
   file->ptr = ptr;


### PR DESCRIPTION
If an entry in the cartridge database specifies use of a save type, then
verify that save type is present in the options. If not, warn and allocate
the save file in RAM.

Fixes #76