### PR TITLE
Fix thread_setname handling for macOS and older Windows APIs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -373,6 +373,8 @@ set(VR4300_SOURCES
 # Build OS_SOURCES list.
 #
 if (DEFINED WIN32)
+  check_symbol_exists(GetThreadId windows.h HAVE_WINDOWS_GETTHREADID)
+  check_symbol_exists(GetCurrentThreadId windows.h HAVE_WINDOWS_GETCURRENTTHREADID)
   include_directories(${PROJECT_SOURCE_DIR}/os/winapi)
   set(EXTRA_OS_EXE WIN32)
   if (NOT MSVC)

--- a/cen64.c
+++ b/cen64.c
@@ -428,9 +428,6 @@ int run_device(struct cen64_device *device, bool no_video) {
     return 1;
   }
 
-  // Silently ignoring when the thread name can't be set.
-  // This can happen on older linux kernels  (<=2.6)
-  // or with a write-protected /proc/self
   cen64_thread_setname(thread, "device");
 
   if (!no_video)
@@ -442,6 +439,7 @@ int run_device(struct cen64_device *device, bool no_video) {
 }
 
 CEN64_THREAD_RETURN_TYPE run_device_thread(void *opaque) {
+  cen64_thread_setname(NULL, "device");
   struct cen64_device *device = (struct cen64_device *) opaque;
 
   device_run(device);

--- a/common.h.in
+++ b/common.h.in
@@ -171,6 +171,9 @@ struct bus_controller;
 void cen64_return(struct bus_controller *bus)
 ;
 
+#cmakedefine HAVE_WINDOWS_GETTHREADID ${HAVE_WINDOWS_GETTHREADID}
+#cmakedefine HAVE_WINDOWS_GETCURRENTTHREADID ${HAVE_WINDOWS_GETCURRENTTHREADID}
+
 #cmakedefine DEBUG_MMIO_REGISTER_ACCESS
 #ifdef DEBUG_MMIO_REGISTER_ACCESS
 #ifndef __cplusplus

--- a/device/device.c
+++ b/device/device.c
@@ -193,6 +193,7 @@ CEN64_THREAD_RETURN_TYPE run_rcp_thread(void *opaque) {
 }
 
 CEN64_THREAD_RETURN_TYPE run_vr4300_thread(void *opaque) {
+  cen64_thread_setname(NULL, "vr4300");
   struct cen64_device *device = (struct cen64_device *) opaque;
 
   while (likely(device->running)) {
@@ -250,9 +251,7 @@ int device_multithread_spin(struct cen64_device *device) {
     return 1;
   }
 
-  // Silently ignoring when the thread name can't be set.
-  // This can happen on older linux kernels  (<=2.6)
-  // or with a write-protected /proc/self
+
   cen64_thread_setname(vr4300_thread, "vr4300");
 
   run_rcp_thread(device);

--- a/os/winapi/thread.h
+++ b/os/winapi/thread.h
@@ -11,6 +11,7 @@
 #ifndef CEN64_OS_WINAPI_THREAD
 #define CEN64_OS_WINAPI_THREAD
 #include "common.h"
+#include <errno.h>
 #include <windows.h>
 
 #define CEN64_THREAD_RETURN_TYPE DWORD
@@ -48,10 +49,20 @@ static inline int cen64_thread_join(cen64_thread *t) {
 }
 
 // Sets the name of the thread to a specific value
+// This function is API dependent and must be called either
+// before starting the thread or with older Windows APIs directly after the creation.
+// If you call it at the wrong time or your OS doesn't support custom thread names
+// the return value will be non-zero.
 static inline int cen64_thread_setname(cen64_thread *t, const char *name) {
-  SetThreadName(GetThreadId(t), name);
+  #ifdef HAVE_WINDOWS_GETTHREADID
+    SetThreadName(GetThreadId(t), name);
+    return 0;
+  #elif HAVE_WINDOWS_GETCURRENTTHREADID
+    SetThreadName(GetCurrentThreadId(), name);
+    return 0;
+  #endif
 
-  return 0;
+  return ENOSYS;
 }
 
 //


### PR DESCRIPTION
sorry for breaking the build earlier @mikeryan. This should fix it