### PR TITLE
Use shuffling operation for VMOV instruction

### DIFF
--- a/arch/x86_64/rsp/rsp.h
+++ b/arch/x86_64/rsp/rsp.h
@@ -235,7 +235,7 @@ __m128i rsp_vdivh(struct rsp *rsp,
   unsigned src, unsigned e, unsigned dest, unsigned de);
 
 __m128i rsp_vmov(struct rsp *rsp,
-  unsigned src, unsigned e, unsigned dest, unsigned de);
+  unsigned src, unsigned e, unsigned dest, rsp_vect_t vt_shuffle);
 
 __m128i rsp_vrcp_vrsq(struct rsp *rsp, uint32_t iw, int dp,
   unsigned src, unsigned e, unsigned dest, unsigned de);

--- a/arch/x86_64/rsp/vmov.c
+++ b/arch/x86_64/rsp/vmov.c
@@ -10,14 +10,17 @@
 #include "rsp/rsp.h"
 
 __m128i rsp_vmov(struct rsp *rsp,
-  unsigned src, unsigned e, unsigned dest, unsigned de) {
+  unsigned src, unsigned e, unsigned dest, rsp_vect_t vt_shuffle) {
   uint16_t data;
 
-  // Get the element from VT.
-  data = rsp->cp2.regs[src].e[e & 0x7];
+  // Copy element into data
+  memcpy(&data, (e & 0x7) + (uint16_t *)&vt_shuffle, sizeof(uint16_t));
+
+  printf("src %d dest %d el %x data %x\n", src, dest, e, data);
+  fflush(stdout);
 
   // Write out the upper part of the result.
-  rsp->cp2.regs[dest].e[de & 0x7] = data;
+  rsp->cp2.regs[dest].e[e & 0x7] = data;
   return rsp_vect_load_unshuffled_operand(rsp->cp2.regs[dest].e);
 }
 

--- a/arch/x86_64/rsp/vmov.c
+++ b/arch/x86_64/rsp/vmov.c
@@ -16,9 +16,6 @@ __m128i rsp_vmov(struct rsp *rsp,
   // Copy element into data
   memcpy(&data, (e & 0x7) + (uint16_t *)&vt_shuffle, sizeof(uint16_t));
 
-  printf("src %d dest %d el %x data %x\n", src, dest, e, data);
-  fflush(stdout);
-
   // Write out the upper part of the result.
   rsp->cp2.regs[dest].e[e & 0x7] = data;
   return rsp_vect_load_unshuffled_operand(rsp->cp2.regs[dest].e);

--- a/rsp/vfunctions.c
+++ b/rsp/vfunctions.c
@@ -293,15 +293,14 @@ rsp_vect_t RSP_VMADN_VMUDN(struct rsp *rsp, uint32_t iw,
 rsp_vect_t RSP_VMOV(struct rsp *rsp, uint32_t iw,
   rsp_vect_t vt_shuffle, rsp_vect_t vs, rsp_vect_t zero) {
   uint16_t *acc = rsp->cp2.acc.e;
-  unsigned de = GET_DE(iw) & 0x7;
-  unsigned e = GET_E(iw) & 0x7;
+  unsigned e = GET_DE(iw) & 0x7;
 
   unsigned dest = GET_VD(iw);
   unsigned src = GET_VT(iw);
 
   write_acc_lo(acc, vt_shuffle);
 
-  return rsp_vmov(rsp, src, e, dest, de);
+  return rsp_vmov(rsp, src, e, dest, vt_shuffle);
 }
 
 //


### PR DESCRIPTION
In the current code base, the `e` part of a VMOV instruction is used to index an element within the vector register `vt`. However, the RSP instead interprets this as a shuffle index, and instead using `de` as an index for both destination `vd` and the shuffled `vt`. This PR implements a fix to correctly emulate the behavior of VMOV instructions.