### PR TITLE
Remove wrong 'const' qualifier for is_viewer pointer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ find_package(Threads REQUIRED)
 
 # If using GCC, configure it accordingly.
 if (${CMAKE_C_COMPILER_ID} MATCHES GNU)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wno-unused-parameter -std=c99")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wno-unused-parameter -std=c99 -Werror=discarded-qualifiers")
 
   # Include architecture-specify machinery.
   execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpmachine

--- a/device/device.c
+++ b/device/device.c
@@ -43,7 +43,8 @@ struct cen64_device *device_create(struct cen64_device *device,
   const struct rom_file *ddrom,
   const struct rom_file *pifrom, const struct rom_file *cart,
   const struct save_file *eeprom, const struct save_file *sram,
-  const struct save_file *flashram, const struct is_viewer *is,
+  const struct save_file *flashram,
+  struct is_viewer *is,
   const struct controller *controller,
   bool no_audio, bool no_video) {
 

--- a/device/device.h
+++ b/device/device.h
@@ -60,7 +60,8 @@ cen64_cold struct cen64_device *device_create(struct cen64_device *device,
   const struct rom_file *ddrom,
   const struct rom_file *pifrom, const struct rom_file *cart,
   const struct save_file *eeprom, const struct save_file *sram,
-  const struct save_file *flashram, const struct is_viewer *is,
+  const struct save_file *flashram,
+  struct is_viewer *is,
   const struct controller *controller,
   bool no_audio, bool no_video);
 


### PR DESCRIPTION
`is_viewer` is commanded from `pi`, so it cannot have 'const' qualifier.
Enabling corresponding GCC warning as a error.