### PR TITLE
Add CI configuration files

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,40 @@
+version: "{branch}-ci-{build}"
+image: Visual Studio 2015
+
+branches:
+  only:
+  - master
+
+environment:
+  matrix:
+  - build: msvc
+    platform: x64
+    CMAKEFILE: "Visual Studio 14 Win64"
+  - build: mingw-w64
+    platform: x64
+    CMAKEFILE: "MSYS Makefiles"
+
+install:
+- appveyor DownloadFile https://cfhcable.dl.sourceforge.net/project/gnuwin32/libiconv/1.9.2-1/libiconv-1.9.2-1.exe
+- libiconv-1.9.2-1.exe /SILENT /SUPPRESSMSGBOXES
+- appveyor DownloadFile http://openal-soft.org/openal-binaries/openal-soft-1.17.2-bin.zip
+- 7z x openal-soft-1.17.2-bin.zip
+
+before_build:
+- set PATH=%PATH%;C:\projects\cen64\openal-soft-1.17.2-bin
+- set PATH=%PATH:C:\Program Files\Git\bin;=%
+- set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
+- if "%build%"=="msvc" set PATH=%PATH%;C:\Program Files (x86)\GnuWin32\bin
+- if "%build%"=="mingw-w64" set PATH=%PATH%;C:\msys64\mingw64;C:\msys64\mingw64\bin;C:\msys64\mingw64\lib;C:\msys64\mingw64\include;C:\msys64\usr\bin\;
+- call "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" %platform%
+- if "%platform%"=="X64" set platform=x64
+
+build_script:
+- mkdir build
+- cd build
+- cmake .. -G "%CMAKEFILE%"
+- if "%build%"=="msvc" MSBuild .\cen64.sln /p:Configuration=Release /p:Platform=%platform%
+- if "%build%"=="mingw-w64" bash -lc "cd /c/projects/cen64/build; make all"
+
+test_script:
+- ctest -C Release --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+notifications:
+  email: false
+
+language: c
+
+branches:
+  only:
+  - master
+
+compiler:
+  - gcc
+  - clang
+os:
+  - linux
+  - osx
+
+matrix:
+  exclude:
+    - os: osx
+      compiler: gcc
+
+addons:
+  apt:
+    packages:
+    - freeglut3
+    - freeglut3-dev
+    - libglew1.5
+    - libglew1.5-dev
+    - libglu1-mesa
+    - libglu1-mesa-dev
+    - libgl1-mesa-glx
+    - libgl1-mesa-dev
+    - libpulse-dev
+    - libalut-dev
+
+before_script:
+  - mkdir release && cd release
+
+script:
+  - cmake ..
+  - make

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ find_package(Threads REQUIRED)
 
 # If using GCC, configure it accordingly.
 if (${CMAKE_C_COMPILER_ID} MATCHES GNU)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wno-unused-parameter -std=c99 -Werror=discarded-qualifiers -Werror=implicit-function-declaration")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wno-unused-parameter -std=c99 -Werror=implicit-function-declaration")
 
   # Include architecture-specify machinery.
   execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpmachine
@@ -106,6 +106,12 @@ if (${CMAKE_C_COMPILER_ID} MATCHES GNU)
   if (GCC_VERSION VERSION_GREATER 4.9 OR GCC_VERSION VERSION_EQUAL 4.9)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ffat-lto-objects")
   endif (GCC_VERSION VERSION_GREATER 4.9 OR GCC_VERSION VERSION_EQUAL 4.9)
+
+  # Check for const-correctness.
+  if (GCC_VERSION VERSION_GREATER 5.1 OR GCC_VERSION VERSION_EQUAL 5.1)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror=discarded-qualifiers")
+  endif (GCC_VERSION VERSION_GREATER 5.1 OR GCC_VERSION VERSION_EQUAL 5.1)
+  
 endif (${CMAKE_C_COMPILER_ID} MATCHES GNU)
 
 # If using Clang, configure it accordingly.


### PR DESCRIPTION
These are configuration files for Travis and Appveyor CI systems.
Travis successfully builds CEN64 with GCC and Clang on Linux, with Msys on Windows and with Clang on OSX.
Appveyor tries to build CEN64 with MSVC, but build is failing due #104.

