### PR TITLE
Disable sanitizer of undefined behavior in Clang builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,11 +148,7 @@ if (${CMAKE_C_COMPILER_ID} MATCHES Clang)
   endif (${CLANG_MACHINE} STREQUAL "arm")
 
   # Set architecture-independent flags.
-  if (APPLE)
-    set(CMAKE_C_FLAGS_DEBUG "-ggdb3 -g3 -O0")
-  else ()
-    set(CMAKE_C_FLAGS_DEBUG "-ggdb3 -g3 -O0 -fsanitize=undefined")
-  endif ()
+  set(CMAKE_C_FLAGS_DEBUG "-ggdb3 -g3 -O0")
   set(CMAKE_C_FLAGS_MINSIZEREL "-Os -DNDEBUG")
   set(CMAKE_C_FLAGS_RELEASE "-O3 -DNDEBUG")
   set(CMAKE_C_FLAGS_RELWITHDEBINFO "-O3 -DNDEBUG -ggdb3 -g3")


### PR DESCRIPTION
Sanitizer makes link failures if 128-bit multiplication is called,
see https://bugs.llvm.org/show_bug.cgi?id=16404 for details.