### PR TITLE
memorymap.c: initialize mappings array with zeros

### DIFF
--- a/bus/memorymap.c
+++ b/bus/memorymap.c
@@ -17,6 +17,7 @@ static void rotate_right(struct memory_map *, struct memory_map_node *);
 
 // Creates a new memory map.
 void create_memory_map(struct memory_map *map) {
+  memset(map->mappings, 0, sizeof(struct memory_map_node) * 19);
   map->next_map_index = 1;
   map->nil = map->mappings;
   map->root = map->nil;


### PR DESCRIPTION
For my experiments, I used to create memory_map on dynamic memory, and it was not initialized with zeroes by default.