### PR TITLE
Use bus_controller pointers instead of type punning

### DIFF
--- a/bus/controller.c
+++ b/bus/controller.c
@@ -117,11 +117,8 @@ static int bus_dead_write(void *opaque, uint32_t address, uint32_t word,
 }
 
 // Issues a read request to the bus.
-int bus_read_word(void *component, uint32_t address, uint32_t *word) {
+int bus_read_word(const struct bus_controller *bus, uint32_t address, uint32_t *word) {
   const struct memory_mapping *node;
-  struct bus_controller *bus;
-
-  memcpy(&bus, component, sizeof(bus));
 
   if (address < RDRAM_BASE_ADDRESS_LEN)
     return read_rdram(bus->ri, address, word);
@@ -137,12 +134,9 @@ int bus_read_word(void *component, uint32_t address, uint32_t *word) {
 }
 
 // Issues a write request to the bus.
-int bus_write_word(void *component,
+int bus_write_word(struct bus_controller *bus,
   uint32_t address, uint32_t word, uint32_t dqm) {
   const struct memory_mapping *node;
-  struct bus_controller *bus;
-
-  memcpy(&bus, component, sizeof(bus));
 
   if (address < RDRAM_BASE_ADDRESS_LEN)
     return write_rdram(bus->ri, address, word & dqm, dqm);

--- a/bus/controller.h
+++ b/bus/controller.h
@@ -49,10 +49,10 @@ struct bus_controller {
 cen64_cold int bus_init(struct bus_controller *bus, int dd_present);
 
 // General-purpose accesssor functions.
-cen64_flatten cen64_hot int bus_read_word(void *component,
+cen64_flatten cen64_hot int bus_read_word(const struct bus_controller *bus,
   uint32_t address, uint32_t *word);
 
-cen64_flatten cen64_hot int bus_write_word(void *component,
+cen64_flatten cen64_hot int bus_write_word(struct bus_controller *bus,
   uint32_t address, uint32_t word, uint32_t dqm);
 
 // For asserting and deasserting RCP interrupts.

--- a/rsp/interface.c
+++ b/rsp/interface.c
@@ -41,7 +41,7 @@ void rsp_dma_read(struct rsp *rsp) {
       uint32_t dest_addr = (dest + j) & 0x1FFC;
       uint32_t word;
 
-      bus_read_word(rsp, source_addr, &word);
+      bus_read_word(rsp->bus, source_addr, &word);
 
       // Update opcode cache.
       if (dest_addr & 0x1000) {
@@ -91,7 +91,7 @@ void rsp_dma_write(struct rsp *rsp) {
       if (!(source_addr & 0x1000))
         word = byteswap_32(word);
 
-      bus_write_word(rsp, dest_addr, word, ~0U);
+      bus_write_word(rsp->bus, dest_addr, word, ~0U);
       j += 4;
     } while (j < length);
 

--- a/si/controller.c
+++ b/si/controller.c
@@ -71,10 +71,10 @@ int si_init(struct si_controller *si, struct bus_controller *bus,
 
   // Specify 8MiB RDRAM for 6102/6105 carts.
   if (si->ram[0x26] == 0x3F && si->ram[0x27] == 0x3F)
-    bus_write_word(si, 0x318, 0x800000, ~0U);
+    bus_write_word(si->bus, 0x318, 0x800000, ~0U);
 
   else if (si->ram[0x26] == 0x91 && si->ram[0x27] == 0x3F)
-    bus_write_word(si, 0x3F0, 0x800000, ~0U);
+    bus_write_word(si->bus, 0x3F0, 0x800000, ~0U);
 
   // initialize EEPROM
   si->eeprom.data = eeprom;

--- a/vr4300/fault.c
+++ b/vr4300/fault.c
@@ -256,13 +256,13 @@ void VR4300_DCM(struct vr4300 *vr4300) {
       int64_t sdata;
 
       paddr &= ~mask;
-      bus_read_word(vr4300, paddr, &hiword);
+      bus_read_word(vr4300->bus, paddr, &hiword);
 
       if (request->access_type != VR4300_ACCESS_DWORD)
         sdata = (uint64_t) hiword << (lshiftamt + 32);
 
       else {
-        bus_read_word(vr4300, paddr + 4, &loword);
+        bus_read_word(vr4300->bus, paddr + 4, &loword);
         sdata = ((uint64_t) hiword << 32) | loword;
         sdata = sdata << lshiftamt;
       }
@@ -280,11 +280,11 @@ void VR4300_DCM(struct vr4300 *vr4300) {
       paddr &= ~mask;
 
       if (request->access_type == VR4300_ACCESS_DWORD) {
-        bus_write_word(vr4300, paddr, data >> 32, dqm >> 32);
+        bus_write_word(vr4300->bus, paddr, data >> 32, dqm >> 32);
         paddr += 4;
       }
  
-      bus_write_word(vr4300, paddr, data, dqm);
+      bus_write_word(vr4300->bus, paddr, data, dqm);
     }
 
     vr4300_common_interlocks(vr4300, MEMORY_WORD_DELAY, 2);
@@ -301,7 +301,7 @@ void VR4300_DCM(struct vr4300 *vr4300) {
     memcpy(data, line->data, sizeof(data));
 
     for (i = 0; i < 4; i++)
-      bus_write_word(vr4300, bus_address + i * 4,
+      bus_write_word(vr4300->bus, bus_address + i * 4,
         data[i ^ (WORD_ADDR_XOR >> 2)], ~0);
   }
 
@@ -311,7 +311,7 @@ void VR4300_DCM(struct vr4300 *vr4300) {
 
   // Fill the cache line.
   for (i = 0; i < 4; i++)
-    bus_read_word(vr4300, paddr + i * 4,
+    bus_read_word(vr4300->bus, paddr + i * 4,
       data + (i ^ (WORD_ADDR_XOR >> 2)));
 
   vr4300_dcache_fill(&vr4300->dcache, vaddr, paddr, data);
@@ -361,7 +361,7 @@ void VR4300_ICB(struct vr4300 *vr4300) {
   unsigned delay;
 
   if (!rfex_latch->cached) {
-    bus_read_word(vr4300, paddr, &rfex_latch->iw);
+    bus_read_word(vr4300->bus, paddr, &rfex_latch->iw);
     delay = MEMORY_WORD_DELAY;
   }
 
@@ -373,7 +373,7 @@ void VR4300_ICB(struct vr4300 *vr4300) {
 
     // Fill the cache line.
     for (i = 0; i < 8; i ++)
-      bus_read_word(vr4300, paddr + i * 4, line + i);
+      bus_read_word(vr4300->bus, paddr + i * 4, line + i);
 
     memcpy(&rfex_latch->iw, line + (vaddr >> 2 & 0x7), sizeof(rfex_latch->iw));
     vr4300_icache_fill(&vr4300->icache, icrf_latch->common.pc, paddr, line);

--- a/vr4300/functions.c
+++ b/vr4300/functions.c
@@ -470,7 +470,7 @@ cen64_cold static int vr4300_cacheop_dc_wb_invalidate(
     memcpy(data, line->data, sizeof(data));
 
     for (i = 0; i < 4; i++)
-      bus_write_word(vr4300, bus_address + i * 4,
+      bus_write_word(vr4300->bus, bus_address + i * 4,
         data[i ^ (WORD_ADDR_XOR >> 2)], ~0);
 
     line->metadata &= ~0x2;
@@ -495,7 +495,7 @@ cen64_cold static int vr4300_cacheop_dc_create_dirty_ex(
     memcpy(data, line->data, sizeof(data));
 
     for (i = 0; i < 4; i++)
-      bus_write_word(vr4300, bus_address + i * 4,
+      bus_write_word(vr4300->bus, bus_address + i * 4,
         data[i ^ (WORD_ADDR_XOR >> 2)], ~0);
 
     delay = DCACHE_ACCESS_DELAY;
@@ -531,7 +531,7 @@ cen64_cold static int vr4300_cacheop_dc_hit_wb_invalidate(
     memcpy(data, line->data, sizeof(data));
 
     for (i = 0; i < 4; i++)
-      bus_write_word(vr4300, bus_address + i * 4,
+      bus_write_word(vr4300->bus, bus_address + i * 4,
         data[i ^ (WORD_ADDR_XOR >> 2)], ~0);
 
     line->metadata &= ~0x1;
@@ -558,7 +558,7 @@ cen64_cold static int vr4300_cacheop_dc_hit_wb(
     memcpy(data, line->data, sizeof(data));
 
     for (i = 0; i < 4; i++)
-      bus_write_word(vr4300, bus_address + i * 4,
+      bus_write_word(vr4300->bus, bus_address + i * 4,
         data[i ^ (WORD_ADDR_XOR >> 2)], ~0);
 
     // TODO: Technically, it's clean now...


### PR DESCRIPTION
Maybe I miss something here, but why not to use bus_controller pointer instead of type punning? It seems to be much more safe, as one do not need to care that `bus` is the first pointer in `component` structure.