### PR TITLE
CI for Debian and MacOS

### DIFF
--- a/.github/workflows/debian-linux.yml
+++ b/.github/workflows/debian-linux.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Install Dependencies
       uses: awalsh128/cache-apt-pkgs-action@latest
       with:
-        packages: freeglut3 freeglut3-dev libglew1.5 libglew1.5-dev libglu1-mesa libglu1-mesa-dev libgl1-mesa-glx libgl1-mesa-dev libpulse-dev libalut-dev mesa-common-dev libopenal-dev
+        packages: freeglut3 freeglut3-dev libglew libglew-dev libglu1-mesa libglu1-mesa-dev libgl1-mesa-glx libgl1-mesa-dev libpulse-dev libalut-dev mesa-common-dev libopenal-dev
         version: 1.0
 
     - name: Build

--- a/.github/workflows/debian-linux.yml
+++ b/.github/workflows/debian-linux.yml
@@ -1,8 +1,6 @@
 name: debian-linux
 
-on:
-  push:
-  pull_request:
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/debian-linux.yml
+++ b/.github/workflows/debian-linux.yml
@@ -8,14 +8,23 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Installing Dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y freeglut3 freeglut3-dev libglew1.5 libglew1.5-dev libglu1-mesa libglu1-mesa-dev libgl1-mesa-glx libgl1-mesa-dev libpulse-dev libalut-dev mesa-common-dev libopenal-dev
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Install Dependencies
+      uses: awalsh128/cache-apt-pkgs-action@latest
+      with:
+        packages: freeglut3 freeglut3-dev libglew1.5 libglew1.5-dev libglu1-mesa libglu1-mesa-dev libgl1-mesa-glx libgl1-mesa-dev libpulse-dev libalut-dev mesa-common-dev libopenal-dev
+        version: 1.0
 
     - name: Build
       run: |
         mkdir build && cd build
         cmake -DCMAKE_BUILD_TYPE=Release ..
         make VERBOSE=1 -j4
+
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: cen64 Debian
+        path: ./build/cen64

--- a/.github/workflows/debian-linux.yml
+++ b/.github/workflows/debian-linux.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Install Dependencies
       uses: awalsh128/cache-apt-pkgs-action@latest
       with:
-        packages: freeglut3 freeglut3-dev libglew libglew-dev libglu1-mesa libglu1-mesa-dev libgl1-mesa-glx libgl1-mesa-dev libpulse-dev libalut-dev mesa-common-dev libopenal-dev
+        packages: freeglut3 freeglut3-dev libglew-dev libglu1-mesa libglu1-mesa-dev libgl1-mesa-glx libgl1-mesa-dev libpulse-dev libalut-dev mesa-common-dev libopenal-dev
         version: 1.0
 
     - name: Build

--- a/.github/workflows/debian-linux.yml
+++ b/.github/workflows/debian-linux.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install Dependencies
       uses: awalsh128/cache-apt-pkgs-action@latest

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Install Dependencies
       uses: tecolicom/actions-use-homebrew-tools@v1
       with:
-        tools: freeglut glew mesa openal-soft
+        tools: freeglut glew mesa openal-soft sdl2
 
     - name: Build
       run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: macos-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install Dependencies
       uses: tecolicom/actions-use-homebrew-tools@v1

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,27 @@
+name: macos
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Install Dependencies
+      uses: tecolicom/actions-use-homebrew-tools@v1
+      with:
+        tools: freeglut glew mesa openal-soft
+
+    - name: Build
+      run: |
+        mkdir build && cd build
+        cmake -DCMAKE_BUILD_TYPE=Release ..
+        make VERBOSE=1 -j4
+
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: cen64 MacOS
+        path: ./build/cen64

--- a/.github/workflows/msys2-windows.yml
+++ b/.github/workflows/msys2-windows.yml
@@ -15,7 +15,7 @@ jobs:
           { msystem: MINGW64, arch: x86_64, extensions: Native }
         ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: temp
           fetch-depth: 0


### PR DESCRIPTION
This fixes the CI on Debian, libglew got renamed.

This also adds CI for MacOS, the executable from the artifact will run if SDL2 is installed through brew.