### PR TITLE
Fix thread arg type for pthread_setname_np

### DIFF
--- a/cen64.c
+++ b/cen64.c
@@ -483,7 +483,7 @@ int run_device(struct cen64_device *device, bool no_video) {
 }
 
 CEN64_THREAD_RETURN_TYPE run_device_thread(void *opaque) {
-  cen64_thread_setname(NULL, "device");
+  cen64_thread_setname((cen64_thread)NULL, "device");
   struct cen64_device *device = (struct cen64_device *) opaque;
 
   device_run(device);

--- a/device/device.c
+++ b/device/device.c
@@ -224,7 +224,7 @@ CEN64_THREAD_RETURN_TYPE run_rcp_thread(void *opaque) {
 }
 
 CEN64_THREAD_RETURN_TYPE run_vr4300_thread(void *opaque) {
-  cen64_thread_setname(NULL, "vr4300");
+  cen64_thread_setname((cen64_thread)NULL, "vr4300");
   struct cen64_device *device = (struct cen64_device *) opaque;
 
   while (likely(device->running)) {

--- a/gdb/gdb.c
+++ b/gdb/gdb.c
@@ -79,7 +79,7 @@ bool gdb_parse_packet(const char* input, int len, const char** command_start, co
 }
 
 CEN64_THREAD_RETURN_TYPE gdb_thread(void *opaque) {
-  cen64_thread_setname(NULL, "gdb");
+  cen64_thread_setname((cen64_thread)NULL, "gdb");
   struct gdb *gdb = (struct gdb *) opaque;
 
   cen64_mutex_lock(&gdb->client_mutex);

--- a/os/posix/thread.h
+++ b/os/posix/thread.h
@@ -45,9 +45,9 @@ static inline int cen64_thread_join(cen64_thread *t) {
 #ifdef __APPLE__
 int pthread_setname_np(const char*);
 #elif __NETBSD__
-int pthread_setname_np(cen64_thread*, const char*, const char*);
+int pthread_setname_np(cen64_thread, const char*, const char*);
 #else
-int pthread_setname_np(cen64_thread*, const char*);
+int pthread_setname_np(cen64_thread, const char*);
 #endif
 
 // Sets the name of the thread to a specific value
@@ -56,7 +56,7 @@ int pthread_setname_np(cen64_thread*, const char*);
 // If you call it at the wrong time or your OS doesn't support custom thread names
 // the return value will be non-zero.
 // If cen64_thread is not set the name of the current thread will be changed.
-static inline int cen64_thread_setname(cen64_thread *t, const char *name) {
+static inline int cen64_thread_setname(cen64_thread t, const char *name) {
   #ifdef __APPLE__
     if (t == NULL)
       return pthread_setname_np(name);

--- a/os/winapi/thread.h
+++ b/os/winapi/thread.h
@@ -57,7 +57,7 @@ static inline int cen64_thread_join(cen64_thread *t) {
 //
 // Windows isn't supported for the moment.
 //
-static inline int cen64_thread_setname(cen64_thread *t, const char *name) {
+static inline int cen64_thread_setname(cen64_thread t, const char *name) {
   return ENOSYS;
 }
 


### PR DESCRIPTION
- change `thread` arg type to `cen64_thread` instead of `cen64_thread *` (`pthread_t` instead of `pthread_t *`) according to definition of `pthread_setname_np` from `<pthread.h>`:
`int pthread_setname_np(pthread_t thread, const char *name);`
fixes gcc14 errors:
```
/build/source/cen64.c:475:24: error: passing argument 1 of 'cen64_thread_setname' makes pointer from integer without a cast [-Wint-conversion]
  475 |   cen64_thread_setname(thread, "device");
      |                        ^~~~~~
      |                        |
      |                        cen64_thread {aka long unsigned int}
In file included from /build/source/device/device.h:26,
                 from /build/source/cen64.c:15:
/build/source/os/posix/thread.h:59:54: note: expected 'cen64_thread *' {aka 'long unsigned int *'} but argument is of type 'cen64_thread' {aka 'lo>
   59 | static inline int cen64_thread_setname(cen64_thread *t, const char *name) {
      |                                        ~~~~~~~~~~~~~~^
```

- add cast to `cen64_thread` from NULL where `cen64_thread` is called with it, fixes gcc14 errors:
```
/build/source/gdb/gdb.c:82:24: error: passing argument 1 of 'cen64_thread_setname' makes integer from pointer without a cast [-Wint-conversion]
   82 |   cen64_thread_setname(NULL, "gdb");
      |                        ^~~~
      |                        |
      |                        void *
/build/source/os/posix/thread.h:59:53: note: expected 'cen64_thread' {aka 'long unsigned int'} but argument is of type 'void *'
   59 | static inline int cen64_thread_setname(cen64_thread t, const char *name) {
      |                                        ~~~~~~~~~~~~~^
```

---

This combined with part from #191:
https://github.com/n64dev/cen64/pull/191/commits/f13bdf94c00a9da3b152ed9fe20001e240215b96
adding casts in `bus/controller.c` (other changes from that commit seem to be already in `master`) should make `cen64` build with gcc14